### PR TITLE
Set default loaded file name in title

### DIFF
--- a/gui/components/Plot_area.py
+++ b/gui/components/Plot_area.py
@@ -929,6 +929,14 @@ class PlotArea(QWidget):
             self.last_plot_params['title'] = ""
         self.plot_widget.setTitle("")
 
+    def set_default_title(self, title):
+        """Set the default title in the input field and apply it"""
+        self.title_input.setText(title)
+        self.current_title = title
+        self.plot_widget.setTitle(title)
+        if hasattr(self, 'last_plot_params'):
+            self.last_plot_params['title'] = title
+
     def enable_insertion(self, text):
         self.text_insertion_mode = True
         self.pending_text= text

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -128,6 +128,11 @@ class MainWindow(QMainWindow):
 
                 self.current_file = file_path
                 self.tool_bar.update_file_name(self.current_file)
+
+                # Set default title to filename without extension
+                filename_without_ext = os.path.splitext(os.path.basename(file_path))[0]
+                self.right_panel.plot_area.set_default_title(filename_without_ext)
+
                 logging.info(f"File loaded successfully. Shape: {self.df.shape}")
                 QMessageBox.information(self, "Success", "File loaded successfully!")
             except Exception as e:


### PR DESCRIPTION
- Added set_default_title() method to PlotArea to set title input and apply it
- Updated load_file() to automatically set plot title to filename without extension
- Title is now populated in the input field when a file is loaded