### PR TITLE
Fix PyQtGraph graphics item parent change error

### DIFF
--- a/gui/components/Plot_area.py
+++ b/gui/components/Plot_area.py
@@ -350,10 +350,8 @@ class PlotArea(QWidget):
                     downsampleMethod='subsample'  # Use subsample for speed
                 )
 
-                if i == 0:
-                    self.plot_widget.addItem(original_curve)
-                else:
-                    viewbox.addItem(original_curve)
+                # Always add to viewbox (not directly to plot_widget) to maintain proper parent hierarchy
+                viewbox.addItem(original_curve)
 
                 self.original_lines.append(original_curve)
                 self.plot_items.append({
@@ -388,10 +386,8 @@ class PlotArea(QWidget):
                         downsampleMethod='subsample'  # Use subsample for speed
                     )
 
-                    if i == 0:
-                        self.plot_widget.addItem(smoothed_curve)
-                    else:
-                        viewbox.addItem(smoothed_curve)
+                    # Always add to viewbox (not directly to plot_widget) to maintain proper parent hierarchy
+                    viewbox.addItem(smoothed_curve)
 
                     self.smoothed_lines.append(smoothed_curve)
                     self.plot_items.append({


### PR DESCRIPTION
Fixed an issue where PlotDataItems were being added directly to PlotWidget instead of to the ViewBox, causing an AttributeError when PyQtGraph tried to access view.autoRangeEnabled().

Changes:
- Modified plot_data() to always add PlotDataItems to viewbox
- Removed conditional logic that added items to plot_widget when i == 0
- Added comments explaining the proper parent hierarchy requirement

This ensures PlotDataItems maintain the correct parent-child relationship with their ViewBox, allowing PyQtGraph's internal view management to work correctly.