### PR TITLE
Refactor smoothing function call with explicit parameters

### DIFF
--- a/gui/components/Plot_area.py
+++ b/gui/components/Plot_area.py
@@ -534,8 +534,13 @@ class PlotArea(QWidget):
         # Apply smoothing if enabled
         if smoothing_params and smoothing_params.get('apply', False):
             try:
-                x_data = self.x_data
-                y_data = apply_smoothing(x_data, y_data, smoothing_params)
+                y_data = apply_smoothing(
+                    y_data,
+                    method=smoothing_params.get('method', 'savgol'),
+                    window_length=smoothing_params.get('window_length', 21),
+                    poly_order=smoothing_params.get('poly_order', 3),
+                    sigma=smoothing_params.get('sigma', 2)
+                )
                 logging.info(f"Applied {smoothing_params.get('method', 'unknown')} smoothing to {column_name}")
             except Exception as e:
                 logging.warning(f"Failed to apply smoothing to {column_name}: {str(e)}")


### PR DESCRIPTION
## Summary
Updated the smoothing function call in `Plot_area.py` to pass parameters explicitly rather than relying on the `x_data` argument and dictionary unpacking.

## Key Changes
- Removed `x_data` from the `apply_smoothing()` function call, as it was not being used
- Refactored to pass smoothing parameters as explicit keyword arguments instead of passing the entire `smoothing_params` dictionary
- Parameters now explicitly extracted with default values:
  - `method` (default: 'savgol')
  - `window_length` (default: 21)
  - `poly_order` (default: 3)
  - `sigma` (default: 2)

## Implementation Details
This change improves code clarity by making the function's expected parameters explicit and visible at the call site. It also ensures that only the necessary parameters are passed to `apply_smoothing()`, reducing potential issues from unexpected dictionary keys being passed through.