### PR TITLE
Fix statistics cache validation logic in statistics_area.py

### DIFF
--- a/gui/components/statistics_area.py
+++ b/gui/components/statistics_area.py
@@ -23,7 +23,7 @@ class StatisticsArea(QWidget):
             df_hash = hashlib.md5(pickle.dumps(df.values.tobytes())).hexdigest()
 
             # Check if we already computed stats for this exact dataframe
-            if df_hash == self._last_df_hash and self._stats_cache:
+            if df_hash == self._last_df_hash and self._last_df_hash is not None:
                 # Use cached statistics
                 return
 


### PR DESCRIPTION
## Summary
Fixed a bug in the cache validation logic for the statistics area component where an empty cache dictionary was incorrectly treated as a cache miss.

## Changes
- Updated the cache hit condition in `update_stats()` method to properly validate the cached hash value
- Changed from checking `self._stats_cache` (which could be an empty dict evaluating to False) to checking `self._last_df_hash is not None`
- This ensures the cache is only considered valid when a previous dataframe hash has actually been computed and stored

## Details
The original condition `if df_hash == self._last_df_hash and self._stats_cache:` had a logical flaw where an empty statistics cache dictionary would evaluate to `False`, causing the cache to be invalidated even when the dataframe hadn't changed. The fix explicitly checks whether `_last_df_hash` has been set (is not None), which is the actual indicator of whether caching is available, rather than relying on the truthiness of the cache container itself.

https://claude.ai/code/session_01R6k1NivJVhuB5FvFr7RaGu