### PR TITLE
Increase polynomial coefficient precision from 4 to 10 decimal places

### DIFF
--- a/gui/components/curve_fitting.py
+++ b/gui/components/curve_fitting.py
@@ -407,7 +407,7 @@ class CurveFitting(QGroupBox):
                 continue
 
             # Format the coefficient
-            coeff_str = f"{coeff:.4f}"
+            coeff_str = f"{coeff:.10f}"
 
             # Build term based on power
             if power == 0:


### PR DESCRIPTION
## Summary
Increased the decimal precision of polynomial coefficients displayed in generated equations from 4 to 10 decimal places for improved accuracy in curve fitting results.

## Changes
- Updated coefficient formatting in `generate_polynomial_equation()` function from `:.4f` to `:.10f` format specifier
- This change affects the polynomial equation string representation used in the GUI

## Details
The precision increase allows users to see more accurate coefficient values when fitting curves, which is particularly important for:
- High-precision scientific calculations
- Better visual representation of the fitted model
- Reduced rounding errors in downstream calculations that may use these displayed values

This is a minimal, non-breaking change that only affects the display precision of coefficients in the polynomial equation output.

https://claude.ai/code/session_01LCwRpuiceVCQXg535ifR3b